### PR TITLE
Support typedecorated types

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Next Release
+============
+
+- Added support for custom types which use sqlalchemy.types.TypeDecorator.
+
 0.1.0
 =====
 

--- a/qsqla/query.py
+++ b/qsqla/query.py
@@ -78,7 +78,8 @@ def requires_types(*types):
     def dec(f):
         @functools.wraps(f)
         def wrapper(arg1, arg2=None):
-            if not any([isinstance(arg1.type, t) for t in types]):
+            arg_basetype = getattr(arg1.type, 'impl', arg1.type)
+            if not any([isinstance(arg_basetype, t) for t in types]):
                 raise TypeError("Cannot apply filter to field {}".format(arg1.name))
             return f(arg1, arg2)
         return wrapper


### PR DESCRIPTION
heyo!

Came across this problem when I tried to use qsqla with some [custom types](http://docs.sqlalchemy.org/en/latest/core/custom_types.html). 

At a14826bb5633a027609df9e9fd970f566edf9ffd, the test fails as follows, as the `CustomDateTime` isn't detected as a `DateTime`. 

```
tests/test_qsqla.py ...........................F

=========================== FAILURES ============================______ TestOperators.test_operation_on_typedecorated_type _______

self = <tests.test_qsqla.TestOperators testMethod=test_operation_on_typedecorated_type>

    def test_operation_on_typedecorated_type(self):
        val = datetime.now() - timedelta(hours=5)
        self.perform_assertion({"name": "l_date", "op": "ne", "val": val},
>                              ['Micha', 'Oli', 'Tom'])

tests/test_qsqla.py:235:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _tests/test_qsqla.py:161: in perform_assertion
    selectable = qsqla.query(self.joined_select, [filter])
qsqla/query.py:275: in query
    restrictions.append(OPERATORS[f["op"]](col, f["val"]))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

arg1 = Column('l_date', CustomDateTime(), table=<query>)
arg2 = datetime.datetime(2017, 7, 7, 9, 25, 30, 944870)

    @functools.wraps(f)
    def wrapper(arg1, arg2=None):
        if not any([isinstance(arg1.type, t) for t in types]):
>           raise TypeError("Cannot apply filter to field {}".format(arg1.name))
E           TypeError: Cannot apply filter to field l_date

qsqla/query.py:82: TypeError
============== 1 failed, 27 passed in 0.60 seconds ==============
```

So, with this change we look at `arg1.type.impl` to determine the type, and if it's missing, fall back on `arg1.type`.