### PR TITLE
Orm support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Next Release
 ============
 
+- Add SQLAlchemy ORM support
+
 0.1.2
 =====
 

--- a/tests/test_qsqla.py
+++ b/tests/test_qsqla.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 from sqlalchemy import (MetaData, Table, Column, DateTime, Integer, String,
                         ForeignKey, create_engine, types, select)
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, relationship
 
 import qsqla.query as qsqla
 
@@ -29,6 +29,9 @@ class User(Base):
     u_id = Column(Integer, primary_key=True)
     u_name = Column(String(16))
     u_l_id = Column(ForeignKey(Location.l_id))
+    location = relationship(Location)
+    u_date = Column(CustomDateTime)
+
 
 
 class TestSqlaSplitOperator(unittest.TestCase):
@@ -87,15 +90,14 @@ class DBTestCase(unittest.TestCase):
         Base.metadata.create_all(self.db)
         self.user = User.__table__
         self.location = Location.__table__
-        self.db.execute(
-            "insert into location values(1, 'Karlsruhe', '{}')".format(
-                self.now))
-        self.db.execute(
-            "insert into location values(2, 'Stuttgart', '{}')".format(
-                self.now))
-        self.db.execute("insert into user_table values(1, 'Micha', 1)")
-        self.db.execute("insert into user_table values(2, 'Oli', 1)")
-        self.db.execute("insert into user_table values(3, 'Tom', 2)")
+        l1 = Location(l_name='Karlsruhe', l_date=self.now)
+        l2 = Location(l_name='Stuttgart', l_date=self.now)
+        self.session.add(l1)
+        self.session.add(l2)
+        self.session.add(User(u_name='Micha', location=l1, u_date=self.now))
+        self.session.add(User(u_name='Oli', location=l1, u_date=self.now))
+        self.session.add(User(u_name='Tom', location=l2, u_date=self.now))
+        self.session.commit()
         self.joined_select = self.location.join(
             self.user, self.location.c.l_id == self.user.c.u_l_id).select()
 
@@ -103,7 +105,7 @@ class DBTestCase(unittest.TestCase):
         Base.metadata.drop_all(self.db)
 
 
-class TestSqlaQuery(DBTestCase):
+class TestSqlaQueryCore(DBTestCase):
     def assertEqualColumns(self, first, second):
         first_columns = set(c.name for c in first.columns)
         second_columns = set(c.name for c in second.columns)
@@ -127,58 +129,86 @@ class TestSqlaQuery(DBTestCase):
         self.assertEqualColumns(self.joined_select, result)
 
     def test_limit(self):
-        query = qsqla.query(self.user.select(),
-                            [],
-                            limit=2)
+        limit = 2
+        query = qsqla.query(self.user.select(), [], limit=limit)
         rows = self.db.execute(query)
+        self.assertEquals(len(list(rows)), limit)
 
+    def test_offset(self):
+        query = qsqla.query(self.user.select(), [], offset=2)
+        rows = self.db.execute(query)
+        self.assertEquals(len(list(rows)), 1)
+
+    def test_order_with_default_ascending(self):
+        query = qsqla.query(self.user.select(), [], order="u_id")
+        rows = self.db.execute(query)
+        self.assertEquals([row.u_id for row in rows], [1, 2, 3])
+
+    def test_order_with_forced_ascending(self):
+        query = qsqla.query(self.user.select(), [], order="u_id", asc=True)
+        rows = self.db.execute(query)
+        self.assertEquals([row.u_id for row in rows], [1, 2, 3])
+
+    def test_order_with_forced_descending(self):
+        query = qsqla.query(self.user.select(), [], order="u_id", asc=False)
+        rows = self.db.execute(query)
+        self.assertEquals([row.u_id for row in rows], [3, 2, 1])
+
+
+class TestSqlaQueryORM(DBTestCase):
+
+    def test_limit(self):
+        query = qsqla.query(User, [], limit=2)
+        query.session = self.session
+        rows = query.all()
         self.assertEquals(len(list(rows)), 2)
 
     def test_offset(self):
-        query = qsqla.query(self.user.select(),
-                            [],
-                            offset=2)
-        rows = self.db.execute(query)
-
-        remaining_rows = 3 - 2
-        self.assertEquals(len(list(rows)), remaining_rows)
+        query = qsqla.query(User, [], offset=2)
+        query.session = self.session
+        rows = query.all()
+        self.assertEquals(len(list(rows)), 1)
 
     def test_order_with_default_ascending(self):
-        query = qsqla.query(self.user.select(),
-                            [],
-                            order="u_id")
-        rows = self.db.execute(query)
+        query = qsqla.query(User, [], order="u_id")
+        query.session = self.session
+        rows = query.all()
         self.assertEquals([row.u_id for row in rows], [1, 2, 3])
 
     def test_order_with_forced_ascending(self):
-        query = qsqla.query(self.user.select(),
-                            [],
-                            order="u_id",
-                            asc=True)
-        rows = self.db.execute(query)
+        query = qsqla.query(User, [], order="u_id", asc=True)
+        query.session = self.session
+        rows = query.all()
         self.assertEquals([row.u_id for row in rows], [1, 2, 3])
 
-    def test_order_with_forced_ascending(self):
-        query = qsqla.query(self.user.select(),
-                            [],
-                            order="u_id",
-                            asc=False)
+    def test_order_with_forced_descending(self):
+        query = qsqla.query(self.user.select(), [], order="u_id", asc=False)
         rows = self.db.execute(query)
         self.assertEquals([row.u_id for row in rows], [3, 2, 1])
 
 
 class TestOperators(DBTestCase):
     def perform_assertion(self, filter, expected_names):
+        # test core
         selectable = qsqla.query(self.joined_select, [filter])
         rows = self.db.execute(selectable)
         self.assertEqual([dict(r)['u_name'] for r in rows], expected_names)
 
+        if filter['name'].startswith('u_'):
+            # test ORM
+            q = qsqla.query(User, [filter])
+            q.session = self.session
+            self.assertEqual([row.u_name for row in q.all()], expected_names)
+
     def test_is_null(self):
         self.perform_assertion({"name": "l_id", "op": "is_null"}, [])
+        self.perform_assertion({"name": "u_id", "op": "is_null"}, [])
 
     def test_is_not_null(self):
         self.perform_assertion({"name": "l_id", "op": "is_not_null"},
                           ['Micha', 'Oli', 'Tom'])
+        self.perform_assertion({"name": "u_id", "op": "is_not_null"},
+                               ['Micha', 'Oli', 'Tom'])
 
     def test_equals(self):
         self.perform_assertion({"name": "l_id", "op": "eq", "val": "1"},
@@ -227,24 +257,38 @@ class TestOperators(DBTestCase):
     def test_like(self):
         self.perform_assertion({"name": "l_name", "op": "like", "val": "%gart%"},
                           ['Tom'])
+        self.perform_assertion({"name": "u_name", "op": "like", "val": "%om%"},
+            ['Tom'])
 
     def test_like_is_case_sensitive(self):
         self.perform_assertion(
             {"name": "l_name", "op": "like", "val": "%gaRT%"},
             [])
+        self.perform_assertion(
+            {"name": "u_name", "op": "like", "val": "%OM%"},
+            [])
 
     def test_not_like(self):
         self.perform_assertion({"name": "l_name", "op": "not_like", "val": "%gart%"},
                           ['Micha', 'Oli'])
+        self.perform_assertion(
+            {"name": "u_name", "op": "not_like", "val": "%om%"},
+            ['Micha', 'Oli'])
 
     def test_ilike(self):
         self.perform_assertion(
             {"name": "l_name", "op": "ilike", "val": "%gaRT%"},
             ['Tom'])
+        self.perform_assertion(
+            {"name": "u_name", "op": "ilike", "val": "%oM%"},
+            ['Tom'])
 
     def test_not_ilike(self):
         self.perform_assertion({"name": "l_name", "op": "not_ilike", "val": "%gaRT%"},
                           ['Micha', 'Oli'])
+        self.perform_assertion(
+            {"name": "u_name", "op": "not_ilike", "val": "%oM%"},
+            ['Micha', 'Oli'])
 
     def test_in_(self):
         self.perform_assertion({"name": "u_id", "op": "in", "val": "1,3"},
@@ -256,18 +300,14 @@ class TestOperators(DBTestCase):
 
     def test_operation_on_typedecorated_type(self):
         val = (datetime.now() - timedelta(hours=5)).isoformat()
-        self.perform_assertion({"name": "l_date", "op": "ne", "val": val},
+        self.perform_assertion({"name": "u_date", "op": "ne", "val": val},
                                ['Micha', 'Oli', 'Tom'])
 
     def test_greater_than_typedecorated_datetime(self):
         datestring = (self.now - timedelta(minutes=1)).isoformat()
-        self.perform_assertion({"name": "l_date", "op": "gt", "val": datestring},
+        self.perform_assertion({"name": "u_date", "op": "gt", "val": datestring},
                           ['Micha', 'Oli', 'Tom'])
         datestring = (self.now + timedelta(minutes=1)).isoformat()
         self.perform_assertion(
             {"name": "l_date", "op": "gt", "val": datestring},
             [])
-
-
-class TestORM(DBTestCase):
-    pass

--- a/tests/test_qsqla.py
+++ b/tests/test_qsqla.py
@@ -104,6 +104,9 @@ class DBTestCase(unittest.TestCase):
 
     def tearDown(self):
         Base.metadata.drop_all(self.db)
+        self.session.commit()
+        self.session.close()
+        self.db.close()
 
 
 class TestSqlaQueryCore(DBTestCase):

--- a/tests/test_qsqla.py
+++ b/tests/test_qsqla.py
@@ -84,8 +84,9 @@ class TestSqlaFilter(unittest.TestCase):
 class DBTestCase(unittest.TestCase):
     def setUp(self):
         dsn = os.environ.get("ENV_DSN", "sqlite:///:memory:")
-        self.db = create_engine(dsn)
-        self.session = sessionmaker(bind=self.db)()
+        self.engine = create_engine(dsn)
+        self.db = self.engine.connect()
+        self.session = sessionmaker()(bind=self.db)
         self.now = datetime.now()
         Base.metadata.create_all(self.db)
         self.user = User.__table__


### PR DESCRIPTION
Sorry about the huge diff. Cleaned some stuff up along the way but it's made it much less readable :(

## Main points
* `query` has been split up between `core_query` and `orm_query`. These two functions just do the filtering. The `query` function remains the main entrypoint, and now accepts a `selectable_or_model` object. Pagination controls also still happen here. 
* I've changed the order of the pagination stuff. Previously, the order was being applied at the very end, after `limit` and `offset` had been applied. Did that make sense? Does it work? Surely it makes more sense to order first and then apply limits and offsets? I get the feeling this was done on purpose to reduce the time spent on the ordering, when a query is done on a large dataset. However, won't it lead to strange effects in the resulting query dataset?
* I removed the `if order_col is None` clause (see here https://github.com/blue-yonder/qsqla/compare/orm_support?expand=1#diff-ce932ae519520ec5815b29135e0d0c98L306 ). Could this have ever happened? `get_column` raises a `KeyError` if it can't find the column, so I don't see how, but maybe I'm missing something. 
* The tests were previously just testing against the `joined_select` selectable, which doesn't really map to an ORM use-case. So I just ensured that all tests test filtering against one `User` attribute at least once, and that in these cases, we also do the ORM filtering. 

I'm not really happy with how this turned out. Forcing the user to use flask-sqlalchemy (so we'd have access to a session-bound `Model.query` function) didn't seem appropriate, so we're left with these `query.session = self.session` lines in the tests. Anyone using this functionality in conjunction with flask-sqlalchemy will probably need to write their own `ModelMixin` that does this automatically (possibly something to put in the docs..) 

Anyway, if you have any ideas on how to better solve this, I'd love to hear them! 